### PR TITLE
Implement validation and seed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Run commands:
 schemaflow generate   # generate migrations
 schemaflow up         # apply pending migrations
 schemaflow down NAME  # rollback to a migration
+schemaflow seed       # execute seed files
+schemaflow validate   # validate migration directory
 schemaflow diff       # print schema differences
 ```
 

--- a/cmd/schemaflow.go
+++ b/cmd/schemaflow.go
@@ -52,6 +52,26 @@ func main() {
 		},
 	})
 
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "seed",
+		Short: "Execute seed SQL files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, err := openDB()
+			if err != nil {
+				return err
+			}
+			return schema.Seed(db, migDir)
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "validate",
+		Short: "Validate migration files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return schema.Validate(migDir)
+		},
+	})
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/seed.go
+++ b/seed.go
@@ -1,0 +1,29 @@
+package schemaflow
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"gorm.io/gorm"
+)
+
+// Seed executes all SQL seed files in the given directory. Files are executed
+// in alphabetical order and must have a `.seed.sql` suffix.
+func Seed(db *gorm.DB, dir string) error {
+	files, err := filepath.Glob(filepath.Join(dir, "*.seed.sql"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		if err := db.Exec(string(b)).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,55 @@
+package schemaflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Validate checks migration files for common issues such as duplicated names
+// or missing down migration files.
+func Validate(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	// track migration versions (prefix before first underscore)
+	seen := make(map[string]struct{})
+	duplicates := []string{}
+	missingDown := []string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".up.sql") {
+			continue
+		}
+		base := strings.TrimSuffix(e.Name(), ".up.sql")
+		ver := base
+		if idx := strings.Index(base, "_"); idx != -1 {
+			ver = base[:idx]
+		}
+		if _, ok := seen[ver]; ok {
+			duplicates = append(duplicates, ver)
+			continue
+		}
+		seen[ver] = struct{}{}
+		if _, err := os.Stat(filepath.Join(dir, base+".down.sql")); os.IsNotExist(err) {
+			missingDown = append(missingDown, base)
+		}
+	}
+	if len(duplicates) > 0 || len(missingDown) > 0 {
+		var sb strings.Builder
+		if len(duplicates) > 0 {
+			sb.WriteString("duplicate migrations: ")
+			sb.WriteString(strings.Join(duplicates, ", "))
+		}
+		if len(missingDown) > 0 {
+			if sb.Len() > 0 {
+				sb.WriteString("; ")
+			}
+			sb.WriteString("missing down files: ")
+			sb.WriteString(strings.Join(missingDown, ", "))
+		}
+		return fmt.Errorf(sb.String())
+	}
+	return nil
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,26 @@
+package schemaflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "001_init", "CREATE TABLE t1(id int);", "DROP TABLE t1;")
+	writeMigration(t, dir, "001_init_again", "CREATE TABLE t2(id int);", "DROP TABLE t2;")
+	if err := Validate(dir); err == nil {
+		t.Fatalf("expected duplicate error")
+	}
+}
+
+func TestValidateMissingDown(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "002_missing.up.sql"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(dir); err == nil {
+		t.Fatalf("expected missing down error")
+	}
+}


### PR DESCRIPTION
## Summary
- add `Validate` function to check migrations for duplicates and missing .down.sql files
- add `Seed` function to execute seed SQL files
- extend CLI with `seed` and `validate` commands
- document new commands in README
- add tests for validation logic

## Testing
- `go test ./...` *(fails: Forbidden network access)*

------
https://chatgpt.com/codex/tasks/task_e_685b18879964833098bb7038e195f658