### PR TITLE
Add generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ go build ./cmd/driftflow
 Run commands:
 
 ```bash
+driftflow generate   # generate migrations from models
 driftflow migrate    # generate migrations and apply them
 driftflow up         # apply pending migrations
 driftflow down NAME  # rollback to a migration

--- a/cmd/driftflow.go
+++ b/cmd/driftflow.go
@@ -65,6 +65,19 @@ func main() {
 	})
 
 	rootCmd.AddCommand(&cobra.Command{
+		Use:   "generate",
+		Short: "Generate migration files from models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, err := openDB()
+			if err != nil {
+				return err
+			}
+			var models []interface{}
+			return driftflow.GenerateMigrations(db, models, migDir)
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "migrate",
 		Short: "Generate and apply migrations from models",
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- add `generate` command to create migration files separately
- document new command in README

## Testing
- `go test ./...` *(fails: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b271352d88330813f1a167c643f02