### PR TITLE
Add ConnectToDB helper

### DIFF
--- a/cmd/driftflow.go
+++ b/cmd/driftflow.go
@@ -119,14 +119,5 @@ func main() {
 }
 
 func openDB() (*gorm.DB, error) {
-	switch driver {
-	case "postgres":
-		return gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	case "sqlite":
-		return gorm.Open(sqlite.Open(dsn), &gorm.Config{})
-	case "mysql":
-		return gorm.Open(mysql.Open(dsn), &gorm.Config{})
-	default:
-		return nil, fmt.Errorf("unsupported driver: %s", driver)
-	}
+	return driftflow.ConnectToDB(dsn, driver)
 }

--- a/connect.go
+++ b/connect.go
@@ -1,0 +1,37 @@
+package driftflow
+
+import (
+	"fmt"
+
+	"DriftFlow/config"
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ConnectToDB opens a database connection using the given DSN and driver. If
+// either parameter is empty, configuration is loaded from environment variables
+// (including values from a .env file if present).
+func ConnectToDB(dsn string, driver string) (*gorm.DB, error) {
+	if dsn == "" || driver == "" {
+		cfg := config.Load()
+		if dsn == "" {
+			dsn = cfg.DSN
+		}
+		if driver == "" {
+			driver = cfg.Driver
+		}
+	}
+
+	switch driver {
+	case "postgres":
+		return gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	case "mysql":
+		return gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	case "sqlite":
+		return gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	default:
+		return nil, fmt.Errorf("unsupported driver: %s", driver)
+	}
+}

--- a/connect_test.go
+++ b/connect_test.go
@@ -1,0 +1,33 @@
+package driftflow
+
+import (
+	"testing"
+)
+
+func TestConnectToDBSQLite(t *testing.T) {
+	db, err := ConnectToDB("file::memory:?cache=shared", "sqlite")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected db instance")
+	}
+}
+
+func TestConnectToDBUnsupported(t *testing.T) {
+	if _, err := ConnectToDB("", "foo"); err == nil {
+		t.Fatalf("expected error for unsupported driver")
+	}
+}
+
+func TestConnectToDBEnv(t *testing.T) {
+	t.Setenv("DSN", "file::memory:?cache=shared")
+	t.Setenv("DB_TYPE", "sqlite")
+	db, err := ConnectToDB("", "")
+	if err != nil {
+		t.Fatalf("connect with env: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected db instance")
+	}
+}


### PR DESCRIPTION
## Summary
- add `ConnectToDB` helper to centralise DB connection logic
- update CLI to use the new helper
- test connection helper

## Testing
- `go test ./...` *(fails: "proxy.golang.org: Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_685b4180b394833091fae11c6e6199ef