### PR TITLE
Implement schema comparison

### DIFF
--- a/compare_test.go
+++ b/compare_test.go
@@ -1,0 +1,64 @@
+package driftflow
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompareSchemas_TableMissing(t *testing.T) {
+	src := map[string]map[string]string{
+		"users": {"id": "int"},
+	}
+	tgt := map[string]map[string]string{}
+
+	expect := []string{"missing table: users"}
+	got := CompareSchemas(src, tgt)
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("expected %v, got %v", expect, got)
+	}
+}
+
+func TestCompareSchemas_ColumnMissing(t *testing.T) {
+	src := map[string]map[string]string{
+		"users": {"id": "int", "name": "text"},
+	}
+	tgt := map[string]map[string]string{
+		"users": {"id": "int"},
+	}
+
+	expect := []string{"missing column: users.name"}
+	got := CompareSchemas(src, tgt)
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("expected %v, got %v", expect, got)
+	}
+}
+
+func TestCompareSchemas_ColumnExtra(t *testing.T) {
+	src := map[string]map[string]string{
+		"users": {"id": "int"},
+	}
+	tgt := map[string]map[string]string{
+		"users": {"id": "int", "name": "text"},
+	}
+
+	expect := []string{"extra column: users.name"}
+	got := CompareSchemas(src, tgt)
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("expected %v, got %v", expect, got)
+	}
+}
+
+func TestCompareSchemas_TypeMismatch(t *testing.T) {
+	src := map[string]map[string]string{
+		"users": {"id": "int"},
+	}
+	tgt := map[string]map[string]string{
+		"users": {"id": "bigint"},
+	}
+
+	expect := []string{"type mismatch for users.id: int vs bigint"}
+	got := CompareSchemas(src, tgt)
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("expected %v, got %v", expect, got)
+	}
+}

--- a/schema_compare.go
+++ b/schema_compare.go
@@ -1,0 +1,51 @@
+package driftflow
+
+import (
+	"fmt"
+	"sort"
+)
+
+// CompareSchemas compares two database schema representations.
+// The schema maps table names to a map of column names and their types.
+// It returns a list of differences such as missing tables, columns or type changes.
+func CompareSchemas(source map[string]map[string]string, target map[string]map[string]string) []string {
+	diffs := []string{}
+
+	// Check tables from source against target
+	for tbl, srcCols := range source {
+		tgtCols, ok := target[tbl]
+		if !ok {
+			diffs = append(diffs, fmt.Sprintf("missing table: %s", tbl))
+			continue
+		}
+
+		// Columns present in source but missing or changed in target
+		for col, srcType := range srcCols {
+			tgtType, ok := tgtCols[col]
+			if !ok {
+				diffs = append(diffs, fmt.Sprintf("missing column: %s.%s", tbl, col))
+				continue
+			}
+			if srcType != tgtType {
+				diffs = append(diffs, fmt.Sprintf("type mismatch for %s.%s: %s vs %s", tbl, col, srcType, tgtType))
+			}
+		}
+
+		// Extra columns in target that are not in source
+		for col := range tgtCols {
+			if _, ok := srcCols[col]; !ok {
+				diffs = append(diffs, fmt.Sprintf("extra column: %s.%s", tbl, col))
+			}
+		}
+	}
+
+	// Extra tables in target not present in source
+	for tbl := range target {
+		if _, ok := source[tbl]; !ok {
+			diffs = append(diffs, fmt.Sprintf("extra table: %s", tbl))
+		}
+	}
+
+	sort.Strings(diffs)
+	return diffs
+}


### PR DESCRIPTION
## Summary
- add `CompareSchemas` for detecting differences between two schema definitions
- test table detection, column changes, and type mismatches

## Testing
- `go test ./...` *(fails: modules cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_685b41b7acd083309b3524ace7c8bd38