### PR TITLE
Implement audit logging

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,46 @@
+package driftflow
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// SchemaAuditLog represents a row in the schema_audit_log table.
+type SchemaAuditLog struct {
+	ID       uint `gorm:"primaryKey"`
+	Version  string
+	Action   string
+	User     string
+	Host     string
+	LoggedAt time.Time `gorm:"autoCreateTime"`
+}
+
+// TableName specifies the database table name for SchemaAuditLog.
+func (SchemaAuditLog) TableName() string { return "schema_audit_log" }
+
+// LogAuditEvent inserts an audit log entry for the given migration version and action.
+// It detects the current user and hostname automatically.
+func LogAuditEvent(db *gorm.DB, version string, action string) {
+	user := os.Getenv("USER")
+	if user == "" {
+		if out, err := exec.Command("whoami").Output(); err == nil {
+			user = strings.TrimSpace(string(out))
+		}
+	}
+
+	host, _ := os.Hostname()
+
+	entry := SchemaAuditLog{
+		Version: version,
+		Action:  action,
+		User:    user,
+		Host:    host,
+	}
+
+	// Ignore error as function signature does not return it.
+	_ = db.Create(&entry).Error
+}

--- a/audit_test.go
+++ b/audit_test.go
@@ -1,0 +1,31 @@
+package driftflow
+
+import (
+	"testing"
+)
+
+func TestLogAuditEvent(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&SchemaAuditLog{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	t.Setenv("USER", "tester")
+
+	LogAuditEvent(db, "001_test", "up")
+
+	var log SchemaAuditLog
+	if err := db.First(&log).Error; err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	if log.Version != "001_test" || log.Action != "up" {
+		t.Fatalf("unexpected log values: %+v", log)
+	}
+	if log.User != "tester" {
+		t.Fatalf("expected user tester, got %s", log.User)
+	}
+	if log.Host == "" {
+		t.Fatalf("expected hostname set")
+	}
+}


### PR DESCRIPTION
## Summary
- add audit logging with `LogAuditEvent`
- test audit logging functionality

## Testing
- `go test ./...` *(fails: `proxy.golang.org` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b420316e48330bcc677485f1d0973