### PR TITLE
Add advanced migration validation

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // Validate checks migration files for common issues such as duplicated names
@@ -18,6 +22,13 @@ func Validate(dir string) error {
 	seen := make(map[string]struct{})
 	duplicates := []string{}
 	missingDown := []string{}
+	namingIssues := []string{}
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		return err
+	}
+
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".up.sql") {
 			continue
@@ -35,8 +46,17 @@ func Validate(dir string) error {
 		if _, err := os.Stat(filepath.Join(dir, base+".down.sql")); os.IsNotExist(err) {
 			missingDown = append(missingDown, base)
 		}
+
+		sqlBytes, err := os.ReadFile(filepath.Join(dir, base+".up.sql"))
+		if err != nil {
+			return err
+		}
+		namingIssues = append(namingIssues, checkNamingConventions(string(sqlBytes))...)
+		if err := dryRunSQL(db, string(sqlBytes)); err != nil {
+			return fmt.Errorf("%s: %w", e.Name(), err)
+		}
 	}
-	if len(duplicates) > 0 || len(missingDown) > 0 {
+	if len(duplicates) > 0 || len(missingDown) > 0 || len(namingIssues) > 0 {
 		var sb strings.Builder
 		if len(duplicates) > 0 {
 			sb.WriteString("duplicate migrations: ")
@@ -49,7 +69,72 @@ func Validate(dir string) error {
 			sb.WriteString("missing down files: ")
 			sb.WriteString(strings.Join(missingDown, ", "))
 		}
+		if len(namingIssues) > 0 {
+			if sb.Len() > 0 {
+				sb.WriteString("; ")
+			}
+			sb.WriteString("naming issues: ")
+			sb.WriteString(strings.Join(namingIssues, ", "))
+		}
 		return fmt.Errorf(sb.String())
 	}
 	return nil
+}
+
+func dryRunSQL(db *gorm.DB, sql string) error {
+	stmts := strings.Split(sql, ";")
+	for _, stmt := range stmts {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if err := db.Exec(stmt).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isSnakeCase(name string) bool {
+	matched, _ := regexp.MatchString(`^[a-z][a-z0-9_]*$`, name)
+	return matched
+}
+
+func checkNamingConventions(sql string) []string {
+	issues := []string{}
+	reTable := regexp.MustCompile("(?i)create\\s+table\\s+([\\w\"`]+)\\s*\\(([^;]+)\\)")
+	tbls := reTable.FindAllStringSubmatch(sql, -1)
+	for _, m := range tbls {
+		tbl := strings.Trim(m[1], "`\"")
+		if !isSnakeCase(tbl) {
+			issues = append(issues, fmt.Sprintf("table %s not snake_case", tbl))
+		}
+		cols := strings.Split(m[2], ",")
+		for _, colLine := range cols {
+			fields := strings.Fields(strings.TrimSpace(colLine))
+			if len(fields) == 0 {
+				continue
+			}
+			col := strings.Trim(fields[0], "`\"")
+			if strings.EqualFold(col, "constraint") || strings.EqualFold(col, "primary") || strings.EqualFold(col, "foreign") {
+				continue
+			}
+			if !isSnakeCase(col) {
+				issues = append(issues, fmt.Sprintf("column %s not snake_case", col))
+			}
+		}
+	}
+	reAlter := regexp.MustCompile("(?i)alter\\s+table\\s+([\\w\"`]+)\\s+add\\s+column\\s+([\\w\"`]+)")
+	alts := reAlter.FindAllStringSubmatch(sql, -1)
+	for _, m := range alts {
+		tbl := strings.Trim(m[1], "`\"")
+		col := strings.Trim(m[2], "`\"")
+		if !isSnakeCase(tbl) {
+			issues = append(issues, fmt.Sprintf("table %s not snake_case", tbl))
+		}
+		if !isSnakeCase(col) {
+			issues = append(issues, fmt.Sprintf("column %s not snake_case", col))
+		}
+	}
+	return issues
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -24,3 +24,24 @@ func TestValidateMissingDown(t *testing.T) {
 		t.Fatalf("expected missing down error")
 	}
 }
+
+func TestValidateNamingConvention(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "003_bad_name", "CREATE TABLE Users(id int);", "DROP TABLE Users;")
+	if err := Validate(dir); err == nil {
+		t.Fatalf("expected naming convention error")
+	}
+}
+
+func TestValidateSQLSyntax(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "004_bad_sql.up.sql"), []byte("CREATE TABLE bad (id int"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "004_bad_sql.down.sql"), []byte("DROP TABLE bad;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Validate(dir); err == nil {
+		t.Fatalf("expected sql syntax error")
+	}
+}


### PR DESCRIPTION
## Summary
- extend migration validator with naming convention and SQL dry-run checks
- add tests for advanced validation

## Testing
- `go test ./...` *(fails: access to golang module proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b5898de288330abe42be4c4a1a712