### PR TITLE
Add dynamic seed template generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ migrations programmatically.
 ### Environment
 
 `SEED_DIR` can be used to specify where JSON seed files are located (default `seeds`).
+
+### Dynamic seed templates
+
+You can provide generator functions to populate template values when using
+`GenerateSeedTemplatesWithData`:
+
+```go
+gens := map[string]func() interface{}{
+    "name": func() interface{} { return "Alice" },
+    "age":  func() interface{} { return 30 },
+}
+driftflow.GenerateSeedTemplatesWithData([]interface{}{User{}}, "seeds", gens)
+```

--- a/seedgen_test.go
+++ b/seedgen_test.go
@@ -32,3 +32,28 @@ func TestGenerateSeedTemplates(t *testing.T) {
 		t.Fatalf("unexpected file:\n%s", got)
 	}
 }
+
+func TestGenerateSeedTemplatesWithData(t *testing.T) {
+	dir := t.TempDir()
+	gens := map[string]func() interface{}{
+		"name": func() interface{} { return "alice" },
+		"age":  func() interface{} { return 30 },
+	}
+	if err := GenerateSeedTemplatesWithData([]interface{}{tmplModel{}}, dir, gens); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "tmplmodel.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	expect := strings.TrimSpace(`[
+  {
+    "name": "alice",
+    "age": 30
+  }
+]`)
+	if got != expect {
+		t.Fatalf("unexpected file:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- extend seedgen with `GenerateSeedTemplatesWithData` to allow custom generators
- add unit test showing dynamic values
- document usage of dynamic seed templates in README

## Testing
- `go test ./...` *(fails: missing dependencies due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685b5a3021188330a825f56b27b5e6a1