### PR TITLE
Record Git commit in audit log

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -44,6 +44,9 @@ func TestLogAuditEvent(t *testing.T) {
 	if log.Host == "" {
 		t.Errorf("expected host to be set, got empty")
 	}
+	if log.Commit == "" {
+		t.Errorf("expected commit hash to be recorded")
+	}
 	if log.LoggedAt.IsZero() {
 		t.Errorf("expected LoggedAt timestamp to be set")
 	}

--- a/cmd/driftflow.go
+++ b/cmd/driftflow.go
@@ -133,9 +133,9 @@ func main() {
 				return err
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tTABLE\tACTION\tDATA\tCREATED_AT")
+			fmt.Fprintln(w, "ID\tVERSION\tCOMMIT\tACTION\tUSER\tHOST\tLOGGED_AT")
 			for _, l := range logs {
-				fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n", l.ID, l.Table, l.Action, l.Data, l.CreatedAt.Format(time.RFC3339))
+				fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n", l.ID, l.Version, l.Commit, l.Action, l.User, l.Host, l.LoggedAt.Format(time.RFC3339))
 			}
 			w.Flush()
 			return nil
@@ -164,9 +164,9 @@ func main() {
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tTABLE\tACTION\tDATA\tCREATED_AT")
+			fmt.Fprintln(w, "ID\tVERSION\tCOMMIT\tACTION\tUSER\tHOST\tLOGGED_AT")
 			for _, l := range logs {
-				fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n", l.ID, l.Table, l.Action, l.Data, l.CreatedAt.Format(time.RFC3339))
+				fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n", l.ID, l.Version, l.Commit, l.Action, l.User, l.Host, l.LoggedAt.Format(time.RFC3339))
 			}
 			w.Flush()
 			return nil

--- a/migrations.go
+++ b/migrations.go
@@ -61,6 +61,7 @@ func Up(db *gorm.DB, dir string) error {
 	if err := ensureMigrationsTable(db); err != nil {
 		return err
 	}
+	_ = EnsureAuditTable(db)
 	ups, _, err := readMigrationFiles(dir)
 	if err != nil {
 		return err
@@ -84,6 +85,7 @@ func Up(db *gorm.DB, dir string) error {
 		if err := recordMigration(db, version); err != nil {
 			return err
 		}
+		LogAuditEvent(db, version, "apply")
 	}
 	return nil
 }
@@ -93,6 +95,7 @@ func Down(db *gorm.DB, dir string, targetVersion string) error {
 	if err := ensureMigrationsTable(db); err != nil {
 		return err
 	}
+	_ = EnsureAuditTable(db)
 	_, downs, err := readMigrationFiles(dir)
 	if err != nil {
 		return err
@@ -123,6 +126,7 @@ func Down(db *gorm.DB, dir string, targetVersion string) error {
 		if err := removeMigration(db, m.Version); err != nil {
 			return err
 		}
+		LogAuditEvent(db, m.Version, "rollback")
 	}
 	return nil
 }

--- a/seed.go
+++ b/seed.go
@@ -17,6 +17,7 @@ type Seeder interface {
 // The file name is derived from the seeder type name in lower case with a .json
 // extension (e.g. Bookmark -> bookmark.json).
 func Seed(db *gorm.DB, dir string, seeders []Seeder) error {
+	_ = EnsureAuditTable(db)
 	for _, s := range seeders {
 		t := reflect.TypeOf(s)
 		if t.Kind() == reflect.Pointer {
@@ -27,6 +28,7 @@ func Seed(db *gorm.DB, dir string, seeders []Seeder) error {
 		if err := s.Seed(db, path); err != nil {
 			return err
 		}
+		LogAuditEvent(db, file, "seed")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- log the current git commit when recording audit events
- include audit table creation in Up/Down/Seed helpers
- print commit info in `driftflow audit` output
- test for commit hash in audit log entries

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b5e191ccc8330a8abedd75bc00bff