### PR TITLE
Implement undo command for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ driftflow generate   # generate migrations from models
 driftflow migrate    # generate migrations and apply them
 driftflow up         # apply pending migrations
 driftflow down NAME  # rollback to a migration
+driftflow undo [n]   # rollback the last n migrations (default 1)
 driftflow seed       # execute JSON seed files
 driftflow seedgen    # generate JSON seed templates
 driftflow validate   # validate migration directory

--- a/cmd/driftflow.go
+++ b/cmd/driftflow.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 	"time"
 
@@ -54,6 +55,27 @@ func main() {
 				return err
 			}
 			return driftflow.Down(db, migDir, args[0])
+		},
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "undo [n]",
+		Short: "Rollback the last n migrations (default 1)",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			steps := 1
+			if len(args) == 1 {
+				var err error
+				steps, err = strconv.Atoi(args[0])
+				if err != nil {
+					return err
+				}
+			}
+			db, err := openDB()
+			if err != nil {
+				return err
+			}
+			return driftflow.DownSteps(db, migDir, steps)
 		},
 	})
 

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -52,3 +52,34 @@ func TestUpAndDown(t *testing.T) {
 		t.Fatalf("users table should remain")
 	}
 }
+
+func TestDownSteps(t *testing.T) {
+	dir := t.TempDir()
+	writeMigration(t, dir, "001_create_users", "CREATE TABLE users(id integer primary key);", "DROP TABLE users;")
+	writeMigration(t, dir, "002_create_addresses", "CREATE TABLE addresses(id integer primary key);", "DROP TABLE addresses;")
+
+	db := setupDB(t)
+
+	if err := Up(db, dir); err != nil {
+		t.Fatalf("up: %v", err)
+	}
+
+	if err := DownSteps(db, dir, 1); err != nil {
+		t.Fatalf("down steps: %v", err)
+	}
+
+	if db.Migrator().HasTable("addresses") {
+		t.Fatalf("addresses table should be dropped")
+	}
+	if !db.Migrator().HasTable("users") {
+		t.Fatalf("users table should remain")
+	}
+
+	if err := DownSteps(db, dir, 1); err != nil {
+		t.Fatalf("down steps 2: %v", err)
+	}
+
+	if db.Migrator().HasTable("users") {
+		t.Fatalf("users table should be dropped")
+	}
+}


### PR DESCRIPTION
## Summary
- add `DownSteps` to rollback the last N migrations
- add `undo` CLI command using `DownSteps`
- document `driftflow undo`
- test new rollback helper

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b5fd442f88330a73b00328a23aba8