### PR TITLE
Implement command registry slice

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -36,7 +36,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&migDir, "migrations", cfg.MigDir, "migrations directory")
 	rootCmd.PersistentFlags().StringVar(&seedDir, "seeds", cfg.SeedDir, "seed data directory")
 
-	for _, cmd := range Commands() {
+	for _, cmd := range Commands {
 		rootCmd.AddCommand(cmd)
 	}
 
@@ -63,22 +63,6 @@ func openDSN(d string) (*gorm.DB, error) {
 		return gorm.Open(sqlserver.Open(d), &gorm.Config{})
 	}
 	return nil, fmt.Errorf("unsupported DSN: %s", d)
-}
-
-// Commands returns all DriftFlow CLI commands.
-func Commands() []*cobra.Command {
-	return []*cobra.Command{
-		newUpCommand(),
-		newDownCommand(),
-		newUndoCommand(),
-		newSeedCommand(),
-		newSeedgenCommand(),
-		newGenerateCommand(),
-		newMigrateCommand(),
-		newValidateCommand(),
-		newAuditCommand(),
-		newCompareCommand(),
-	}
 }
 
 func newUpCommand() *cobra.Command {

--- a/cli/registry.go
+++ b/cli/registry.go
@@ -1,0 +1,16 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+var Commands = []*cobra.Command{
+	newUpCommand(),
+	newDownCommand(),
+	newUndoCommand(),
+	newSeedCommand(),
+	newSeedgenCommand(),
+	newGenerateCommand(),
+	newMigrateCommand(),
+	newValidateCommand(),
+	newAuditCommand(),
+	newCompareCommand(),
+}


### PR DESCRIPTION
## Summary
- keep list of CLI commands in `Commands` slice
- use `Commands` when building root command

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d907aaf608330a9f57ff0120c0834