### PR TITLE
Refactor NewRootCommand to use command registry

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -36,9 +36,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&migDir, "migrations", cfg.MigDir, "migrations directory")
 	rootCmd.PersistentFlags().StringVar(&seedDir, "seeds", cfg.SeedDir, "seed data directory")
 
-	for _, cmd := range Commands {
-		rootCmd.AddCommand(cmd)
-	}
+	rootCmd.AddCommand(Commands...)
 
 	return rootCmd
 }


### PR DESCRIPTION
## Summary
- refactor NewRootCommand to add commands via the registry slice

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d9523b60483308c0b014e482021a2