### PR TITLE
Add directory validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ to the default file bundled with the library if none is found:
 - `DB_TYPE` sets the database driver (`postgres`, `mysql`, `sqlserver`). Defaults to `postgres`.
 - `DSN` provides the full database connection string. When not set, a DSN is assembled from `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` and `DB_SSLMODE`.
 - `MIG_DIR` specifies where `.sql` migration files live (default `migrations`).
-- `SEED_DIR` specifies where JSON seed files live (default `seeds`).
+- `SEED_DIR` specifies where JSON seed files live (default `seeds`). Both directories must exist when running migrations or seeds.
 
 `loader.Load` uses the `MIG_DIR` value when called without a directory.
 

--- a/config/config.go
+++ b/config/config.go
@@ -93,3 +93,29 @@ func loadEnvFile() error {
 	}
 	return nil
 }
+
+// ValidateDir checks that dir exists and is a directory.
+func ValidateDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("directory does not exist: %s", dir)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a directory: %s", dir)
+	}
+	return nil
+}
+
+// ValidateDirs verifies that both migration and seed directories exist.
+func ValidateDirs(migDir, seedDir string) error {
+	if err := ValidateDir(migDir); err != nil {
+		return err
+	}
+	if err := ValidateDir(seedDir); err != nil {
+		return err
+	}
+	return nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := ValidateDir(dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := ValidateDir(dir); err == nil {
+		t.Fatalf("expected error for missing dir")
+	}
+}
+
+func TestValidateDirs(t *testing.T) {
+	base := t.TempDir()
+	m := filepath.Join(base, "m")
+	s := filepath.Join(base, "s")
+	os.Mkdir(m, 0o755)
+	os.Mkdir(s, 0o755)
+	if err := ValidateDirs(m, s); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	os.RemoveAll(m)
+	if err := ValidateDirs(m, s); err == nil {
+		t.Fatalf("expected error for missing mig dir")
+	}
+}

--- a/migrations.go
+++ b/migrations.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+
+	"github.com/misaelcrespo30/DriftFlow/config"
 )
 
 // SchemaMigration represents a row in the schema_migrations table.
@@ -58,6 +60,9 @@ func removeMigration(db *gorm.DB, version string) error {
 
 // Up applies all pending migrations found in dir.
 func Up(db *gorm.DB, dir string) error {
+	if err := config.ValidateDir(dir); err != nil {
+		return err
+	}
 	if err := ensureMigrationsTable(db); err != nil {
 		return err
 	}
@@ -92,6 +97,9 @@ func Up(db *gorm.DB, dir string) error {
 
 // Down rolls back migrations until targetVersion is reached.
 func Down(db *gorm.DB, dir string, targetVersion string) error {
+	if err := config.ValidateDir(dir); err != nil {
+		return err
+	}
 	if err := ensureMigrationsTable(db); err != nil {
 		return err
 	}
@@ -135,6 +143,9 @@ func Down(db *gorm.DB, dir string, targetVersion string) error {
 // or greater than the number of applied migrations, all applied migrations are
 // rolled back.
 func DownSteps(db *gorm.DB, dir string, steps int) error {
+	if err := config.ValidateDir(dir); err != nil {
+		return err
+	}
 	if err := ensureMigrationsTable(db); err != nil {
 		return err
 	}

--- a/seed.go
+++ b/seed.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"gorm.io/gorm"
+
+	"github.com/misaelcrespo30/DriftFlow/config"
 )
 
 // Seeder defines a type that can seed itself using a JSON file.
@@ -17,6 +19,9 @@ type Seeder interface {
 // The file name is derived from the seeder type name in lower case with a .json
 // extension (e.g. Bookmark -> bookmark.json).
 func Seed(db *gorm.DB, dir string, seeders []Seeder) error {
+	if err := config.ValidateDir(dir); err != nil {
+		return err
+	}
 	_ = EnsureAuditTable(db)
 	for _, s := range seeders {
 		t := reflect.TypeOf(s)

--- a/validate.go
+++ b/validate.go
@@ -6,11 +6,16 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/misaelcrespo30/DriftFlow/config"
 )
 
 // Validate checks migration files for common issues such as duplicated names
 // or missing down migration files.
 func Validate(dir string) error {
+	if err := config.ValidateDir(dir); err != nil {
+		return err
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- validate migration and seed directories at runtime
- document directory validation in README
- add tests for directory helpers

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dabb471708330a159b5635f1a73c0