### PR TITLE
Add migDir traces

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -150,6 +150,7 @@ func newGenerateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			fmt.Printf("newGenerateCommand migDir=%s\n", migDir)
 			var models []interface{}
 			return driftflow.GenerateMigrations(db, models, migDir)
 		},

--- a/migrations.go
+++ b/migrations.go
@@ -191,6 +191,7 @@ func DownSteps(db *gorm.DB, dir string, steps int) error {
 // for any new tables or columns found in the provided models. Only basic
 // additions are handled.
 func GenerateMigrations(db *gorm.DB, models []interface{}, dir string) error {
+	fmt.Printf("GenerateMigrations dir=%s\n", dir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- print migDir value from the CLI's generate command
- log directory path in `GenerateMigrations`

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685db282d87883309884029d82372028