### PR TITLE
Add EnsureEnvFile helper

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+var defaultEnv = map[string]string{
+	"DB_TYPE":     "postgres",
+	"DSN":         "",
+	"DB_HOST":     "localhost",
+	"DB_PORT":     "5432",
+	"DB_NAME":     "driftflow",
+	"DB_USER":     "user",
+	"DB_PASSWORD": "password",
+	"DB_SSLMODE":  "disable",
+	"MIG_DIR":     "migrations",
+	"SEED_DIR":    "seeds",
+}
+
+var defaultEnvOrder = []string{
+	"DB_TYPE",
+	"DSN",
+	"DB_HOST",
+	"DB_PORT",
+	"DB_NAME",
+	"DB_USER",
+	"DB_PASSWORD",
+	"DB_SSLMODE",
+	"MIG_DIR",
+	"SEED_DIR",
+}
+
+var defaultEnvContent = buildDefaultEnvContent()
+
+func buildDefaultEnvContent() string {
+	var sb strings.Builder
+	for _, k := range defaultEnvOrder {
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		sb.WriteString(defaultEnv[k])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// EnsureEnvFile creates a .env file at path if it doesn't exist using the
+// default environment values.
+func EnsureEnvFile(path string) error {
+	if path == "" {
+		path = ".env"
+	}
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(path, []byte(defaultEnvContent), 0o644)
+}

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureEnvFileCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := EnsureEnvFile(path); err != nil {
+		t.Fatalf("EnsureEnvFile: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(b) != defaultEnvContent {
+		t.Fatalf("unexpected content:\n%s", string(b))
+	}
+}
+
+func TestEnsureEnvFileNoOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	initial := []byte("EXISTING=1\n")
+	if err := os.WriteFile(path, initial, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := EnsureEnvFile(path); err != nil {
+		t.Fatalf("EnsureEnvFile: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(b) != string(initial) {
+		t.Fatalf("file overwritten")
+	}
+}


### PR DESCRIPTION
## Summary
- add config/env.go with env file helpers
- generate default env content dynamically
- ensure .env file is created with defaults
- test EnsureEnvFile behavior

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dbba07b648330a489d67b996bfaab