### PR TITLE
Add models directory support

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,4 @@ DB_SSLMODE=disable
 # Directory paths
 MIG_DIR=migrations
 SEED_DIR=seeds
+MODELS_DIR=models

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ to the default file bundled with the library if none is found:
 - `DSN` provides the full database connection string. When not set, a DSN is assembled from `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` and `DB_SSLMODE`.
 - `MIG_DIR` specifies where `.sql` migration files live (default `migrations`).
 - `SEED_DIR` specifies where JSON seed files live (default `seeds`). Both directories must exist when running migrations or seeds.
+- `MODELS_DIR` sets the directory containing Go model definitions used to generate migrations (default `models`).
 
 If no `.env` file exists, `config.EnsureEnvFile` will create one using the
 defaults in `config.defaultEnv`. When a file is present but missing any of these

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -17,13 +17,15 @@ import (
 
 	driftflow "github.com/misaelcrespo30/DriftFlow"
 	"github.com/misaelcrespo30/DriftFlow/config"
+	"github.com/misaelcrespo30/DriftFlow/helpers"
 )
 
 var (
-	dsn     string
-	driver  string
-	migDir  string
-	seedDir string
+	dsn       string
+	driver    string
+	migDir    string
+	seedDir   string
+	modelsDir string
 )
 
 // NewRootCommand builds the DriftFlow CLI root command. It can be used by
@@ -35,6 +37,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&driver, "driver", cfg.Driver, "database driver")
 	rootCmd.PersistentFlags().StringVar(&migDir, "migrations", cfg.MigDir, "migrations directory")
 	rootCmd.PersistentFlags().StringVar(&seedDir, "seeds", cfg.SeedDir, "seed data directory")
+	rootCmd.PersistentFlags().StringVar(&modelsDir, "models", cfg.ModelsDir, "models directory")
 
 	rootCmd.AddCommand(Commands...)
 
@@ -150,8 +153,10 @@ func newGenerateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("newGenerateCommand migDir=%s\n", migDir)
-			var models []interface{}
+			models, err := helpers.LoadModels(modelsDir)
+			if err != nil {
+				return err
+			}
 			return driftflow.GenerateMigrations(db, models, migDir)
 		},
 	}
@@ -166,7 +171,10 @@ func newMigrateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var models []interface{}
+			models, err := helpers.LoadModels(modelsDir)
+			if err != nil {
+				return err
+			}
 			return driftflow.Migrate(db, migDir, models)
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,10 +12,11 @@ import (
 
 // Config contains the minimal configuration required by the DriftFlow CLI.
 type Config struct {
-	DSN     string
-	Driver  string
-	MigDir  string
-	SeedDir string
+	DSN       string
+	Driver    string
+	MigDir    string
+	SeedDir   string
+	ModelsDir string
 }
 
 // Load reads environment variables (from the system or a .env file) and
@@ -26,10 +27,11 @@ func Load() *Config {
 
 	driver := getEnvOrDefault("DB_TYPE", "postgres")
 	cfg := &Config{
-		DSN:     os.Getenv("DSN"),
-		Driver:  driver,
-		MigDir:  getEnvOrDefault("MIG_DIR", "migrations"),
-		SeedDir: getEnvOrDefault("SEED_DIR", "seeds"),
+		DSN:       os.Getenv("DSN"),
+		Driver:    driver,
+		MigDir:    getEnvOrDefault("MIG_DIR", "migrations"),
+		SeedDir:   getEnvOrDefault("SEED_DIR", "seeds"),
+		ModelsDir: getEnvOrDefault("MODELS_DIR", "models"),
 	}
 
 	if cfg.DSN == "" {

--- a/config/env.go
+++ b/config/env.go
@@ -16,6 +16,7 @@ var defaultEnv = map[string]string{
 	"DB_SSLMODE":  "disable",
 	"MIG_DIR":     "migrations",
 	"SEED_DIR":    "seeds",
+	"MODELS_DIR":  "models",
 }
 
 var defaultEnvOrder = []string{
@@ -29,6 +30,7 @@ var defaultEnvOrder = []string{
 	"DB_SSLMODE",
 	"MIG_DIR",
 	"SEED_DIR",
+	"MODELS_DIR",
 }
 
 var defaultEnvContent = buildDefaultEnvContent()

--- a/helpers/model_loader.go
+++ b/helpers/model_loader.go
@@ -1,0 +1,29 @@
+package helpers
+
+import (
+	"fmt"
+	"path/filepath"
+	"plugin"
+)
+
+// LoadModels loads a plugin named models.so in dir and returns the Models symbol.
+// The plugin must export a variable or function named "Models" of type
+// []interface{} or *[]interface{}.
+func LoadModels(dir string) ([]interface{}, error) {
+	p, err := plugin.Open(filepath.Join(dir, "models.so"))
+	if err != nil {
+		return nil, err
+	}
+	sym, err := p.Lookup("Models")
+	if err != nil {
+		return nil, err
+	}
+	switch m := sym.(type) {
+	case []interface{}:
+		return m, nil
+	case *[]interface{}:
+		return *m, nil
+	default:
+		return nil, fmt.Errorf("invalid Models symbol")
+	}
+}


### PR DESCRIPTION
## Summary
- add MODELS_DIR to configuration
- expose new `--models` flag in CLI
- load models from `models.so` plugin when running `generate` and `migrate`
- document MODELS_DIR environment variable

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685dcf6e861c8330861991c2b6a5f3e8