### PR TITLE
Update model loader for new ssa interpreter API

### DIFF
--- a/helpers/model_loader.go
+++ b/helpers/model_loader.go
@@ -30,12 +30,20 @@ func LoadModels(dir string) ([]interface{}, error) {
 		return nil, fmt.Errorf("Models function not found")
 	}
 
-	i := interp.New(interp.Config{}, prog)
-	v, err := i.Eval(modelsFn)
+	// Create a new interpreter instance with the updated API. In recent
+	// versions the configuration struct was renamed to Options and the
+	// constructor is NewInterpreter rather than New.
+	i := interp.NewInterpreter(prog, &interp.Options{})
+
+	// Execute the function using Call which replaces the old Eval method.
+	v, err := i.Call(modelsFn)
 	if err != nil {
 		return nil, err
 	}
-	if res, ok := v.Interface().([]interface{}); ok {
+
+	// The returned value no longer exposes Interface directly. Instead we
+	// obtain the Go value using ToInterface.
+	if res, ok := v.ToInterface().([]interface{}); ok {
 		return res, nil
 	}
 	return nil, fmt.Errorf("invalid Models return type")


### PR DESCRIPTION
## Summary
- update `helpers/model_loader.go` to use the new `interp` API

## Testing
- `go vet ./...` *(fails: github.com/joho/godotenv@v1.5.1: Forbidden)*
- `go test ./...` *(fails: github.com/joho/godotenv@v1.5.1: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68602596fc6083308a85f81967b487a1