### PR TITLE
Add timestamp prefix to generated migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ driftflow seedgen    # generate JSON seed templates
 driftflow validate   # validate migration directory
 ```
 
+### Migration file naming
+
+Generated migrations use a timestamp prefix similar to other frameworks. Files
+are created as `YYYYMMDDHHMMSS_table.up.sql` and `YYYYMMDDHHMMSS_table.down.sql`.
+This keeps migrations ordered chronologically and simplifies rollbacks.
+
 The package also exposes a Go API for loading migration state and executing
 migrations programmatically.
 

--- a/migrations.go
+++ b/migrations.go
@@ -279,7 +279,8 @@ func GenerateMigrations(db *gorm.DB, models []interface{}, dir string) error {
 		upSQL := fmt.Sprintf("CREATE TABLE %s (\n  %s\n);\n", table, strings.Join(cols, ",\n  "))
 		downSQL := fmt.Sprintf("DROP TABLE %s;\n", table)
 
-		prefix := fmt.Sprintf("%04d_%s", i+1, table)
+		timestamp := time.Now().UTC().Add(time.Duration(i) * time.Second).Format("20060102150405")
+		prefix := fmt.Sprintf("%s_%s", timestamp, table)
 		upPath := filepath.Join(dir, prefix+".up.sql")
 		downPath := filepath.Join(dir, prefix+".down.sql")
 		if _, err := os.Stat(upPath); os.IsNotExist(err) {


### PR DESCRIPTION
## Summary
- prefix generated migrations with `YYYYMMDDHHMMSS` timestamps
- document the naming convention in the README

## Testing
- `go test ./...` *(fails: Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6860396f40d0833087e5fa742216479b