### PR TITLE
Add MIGRATIONS_PATH and rollback alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ driftflow migrate    # generate migrations and apply them
 driftflow up         # apply pending migrations
 driftflow down NAME  # rollback to a migration
 driftflow undo [n]   # rollback the last n migrations (default 1)
+driftflow rollback [n] # alias of undo
 driftflow seed       # execute JSON seed files
 driftflow seedgen    # generate JSON seed templates
 driftflow validate   # validate migration directory
@@ -67,7 +68,7 @@ to the default file bundled with the library if none is found:
 
 - `DB_TYPE` sets the database driver (`postgres`, `mysql`, `sqlserver`). Defaults to `postgres`.
 - `DSN` provides the full database connection string. When not set, a DSN is assembled from `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` and `DB_SSLMODE`.
-- `MIG_DIR` specifies where `.sql` migration files live (default `migrations`).
+- `MIG_DIR` (or `MIGRATIONS_PATH`) specifies where `.sql` migration files live (default `migrations`). When both are set, `MIGRATIONS_PATH` takes precedence.
 - `SEED_DIR` specifies where JSON seed files live (default `seeds`). Both directories must exist when running migrations or seeds.
 - `MODELS_DIR` sets the directory containing Go model definitions used to generate migrations (default `models`).
 
@@ -75,7 +76,7 @@ If no `.env` file exists, `config.EnsureEnvFile` will create one using the
 defaults in `config.defaultEnv`. When a file is present but missing any of these
 keys, they are appended automatically with their default values.
 
-`loader.Load` uses the `MIG_DIR` value when called without a directory.
+`loader.Load` uses the `MIG_DIR` (or `MIGRATIONS_PATH`) value when called without a directory.
 
 ### Dynamic seed templates
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -123,6 +123,29 @@ func newUndoCommand() *cobra.Command {
 	}
 }
 
+func newRollbackCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rollback [n]",
+		Short: "Rollback the last n migrations (default 1)",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			steps := 1
+			if len(args) == 1 {
+				var err error
+				steps, err = strconv.Atoi(args[0])
+				if err != nil {
+					return err
+				}
+			}
+			db, err := openDB()
+			if err != nil {
+				return err
+			}
+			return driftflow.DownSteps(db, migDir, steps)
+		},
+	}
+}
+
 func newSeedCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "seed",

--- a/cli/registry.go
+++ b/cli/registry.go
@@ -6,6 +6,7 @@ var Commands = []*cobra.Command{
 	newUpCommand(),
 	newDownCommand(),
 	newUndoCommand(),
+	newRollbackCommand(),
 	newSeedCommand(),
 	newSeedgenCommand(),
 	newGenerateCommand(),

--- a/config/config.go
+++ b/config/config.go
@@ -26,10 +26,15 @@ func Load() *Config {
 	_ = loadEnvFile()
 
 	driver := getEnvOrDefault("DB_TYPE", "postgres")
+	migPath := os.Getenv("MIGRATIONS_PATH")
+	if migPath == "" {
+		migPath = getEnvOrDefault("MIG_DIR", "migrations")
+	}
+
 	cfg := &Config{
 		DSN:       os.Getenv("DSN"),
 		Driver:    driver,
-		MigDir:    getEnvOrDefault("MIG_DIR", "migrations"),
+		MigDir:    migPath,
 		SeedDir:   getEnvOrDefault("SEED_DIR", "seeds"),
 		ModelsDir: getEnvOrDefault("MODELS_DIR", "models"),
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,3 +33,14 @@ func TestValidateDirs(t *testing.T) {
 		t.Fatalf("expected error for missing mig dir")
 	}
 }
+
+func TestLoad_MigrationsPath(t *testing.T) {
+	old := os.Getenv("MIGRATIONS_PATH")
+	t.Setenv("MIGRATIONS_PATH", "/tmp/migs")
+	defer os.Setenv("MIGRATIONS_PATH", old)
+
+	cfg := Load()
+	if cfg.MigDir != "/tmp/migs" {
+		t.Fatalf("expected /tmp/migs, got %s", cfg.MigDir)
+	}
+}

--- a/config/env.go
+++ b/config/env.go
@@ -6,18 +6,19 @@ import (
 )
 
 var defaultEnv = map[string]string{
-	"DB_TYPE":      "postgres",
-	"DSN":          "",
-	"DB_HOST":      "localhost",
-	"DB_PORT":      "5432",
-	"DB_NAME":      "driftflow",
-	"DB_USER":      "user",
-	"DB_PASSWORD":  "password",
-	"DB_SSLMODE":   "disable",
-	"MIG_DIR":      "migrations",
-	"SEED_DIR":     "seeds",
-	"MODELS_DIR":   "models",
-	"PROJECT_PATH": "",
+	"DB_TYPE":         "postgres",
+	"DSN":             "",
+	"DB_HOST":         "localhost",
+	"DB_PORT":         "5432",
+	"DB_NAME":         "driftflow",
+	"DB_USER":         "user",
+	"DB_PASSWORD":     "password",
+	"DB_SSLMODE":      "disable",
+	"MIG_DIR":         "migrations",
+	"MIGRATIONS_PATH": "",
+	"SEED_DIR":        "seeds",
+	"MODELS_DIR":      "models",
+	"PROJECT_PATH":    "",
 }
 
 var defaultEnvOrder = []string{
@@ -30,6 +31,7 @@ var defaultEnvOrder = []string{
 	"DB_PASSWORD",
 	"DB_SSLMODE",
 	"MIG_DIR",
+	"MIGRATIONS_PATH",
 	"SEED_DIR",
 	"MODELS_DIR",
 	"PROJECT_PATH",

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Load returns the migration state by reading `.sql` files from dir. If dir is
-// empty, it falls back to the `MIG_DIR` configuration loaded from the
-// environment.
+// empty, it falls back to the `MIG_DIR` (or `MIGRATIONS_PATH`) configuration
+// loaded from the environment.
 func Load(_ context.Context, dir string) (*state.State, error) {
 	if dir == "" {
 		dir = config.Load().MigDir

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -56,3 +56,26 @@ func TestLoad_Env(t *testing.T) {
 		t.Fatalf("expected %v, got %v", want, st.Files)
 	}
 }
+
+func TestLoad_MigrationsPath(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"x.sql"}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte{}, 0644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+
+	old := os.Getenv("MIGRATIONS_PATH")
+	t.Setenv("MIGRATIONS_PATH", dir)
+	defer os.Setenv("MIGRATIONS_PATH", old)
+
+	st, err := Load(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{filepath.Join(dir, "x.sql")}
+	if !reflect.DeepEqual(st.Files, want) {
+		t.Fatalf("expected %v, got %v", want, st.Files)
+	}
+}

--- a/migrations.go
+++ b/migrations.go
@@ -22,6 +22,10 @@ type SchemaMigration struct {
 	AppliedAt time.Time `gorm:"autoCreateTime"`
 }
 
+func (SchemaMigration) TableName() string {
+	return "migrations_history"
+}
+
 // ensureMigrationsTable creates the schema_migrations table if it does not exist.
 func ensureMigrationsTable(db *gorm.DB) error {
 	return db.AutoMigrate(&SchemaMigration{})


### PR DESCRIPTION
## Summary
- allow configuration through `MIGRATIONS_PATH` env var
- rename migrations table via TableName
- add `rollback` CLI command
- document new settings and command
- support MIGRATIONS_PATH in loader
- tests for the new env variable

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686051f8bc188330a9e6ef36eebe3c2e