### PR TITLE
Add field change history logging

### DIFF
--- a/field_history.go
+++ b/field_history.go
@@ -1,0 +1,41 @@
+package driftflow
+
+import (
+	"gorm.io/gorm"
+	"time"
+)
+
+// FieldHistory represents a change to a table column.
+type FieldHistory struct {
+	ID         uint `gorm:"primaryKey"`
+	Version    string
+	TableName  string
+	ColumnName string
+	OldType    string
+	NewType    string
+	ChangedAt  time.Time `gorm:"autoCreateTime"`
+}
+
+func (FieldHistory) TableName() string {
+	return "schema_field_history"
+}
+
+// EnsureFieldHistoryTable ensures the schema_field_history table exists.
+func EnsureFieldHistoryTable(db *gorm.DB) error {
+	return db.AutoMigrate(&FieldHistory{})
+}
+
+func logFieldAdd(db *gorm.DB, version, table, column, newType string) {
+	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, NewType: newType}
+	_ = db.Create(&entry).Error
+}
+
+func logFieldRemove(db *gorm.DB, version, table, column, oldType string) {
+	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, OldType: oldType}
+	_ = db.Create(&entry).Error
+}
+
+func logFieldAlter(db *gorm.DB, version, table, column, fromType, toType string) {
+	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, OldType: fromType, NewType: toType}
+	_ = db.Create(&entry).Error
+}


### PR DESCRIPTION
## Summary
- track field changes in new `schema_field_history` table
- log field additions, removals and alterations when generating migrations
- ensure the new table exists when applying or rolling back migrations

## Testing
- `go test ./...` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68605a8f3df88330bfee54153737a752