### PR TITLE
fix struct field name conflict

### DIFF
--- a/field_history.go
+++ b/field_history.go
@@ -9,7 +9,7 @@ import (
 type FieldHistory struct {
 	ID         uint `gorm:"primaryKey"`
 	Version    string
-	TableName  string
+	Table      string
 	ColumnName string
 	OldType    string
 	NewType    string
@@ -26,16 +26,16 @@ func EnsureFieldHistoryTable(db *gorm.DB) error {
 }
 
 func logFieldAdd(db *gorm.DB, version, table, column, newType string) {
-	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, NewType: newType}
+	entry := FieldHistory{Version: version, Table: table, ColumnName: column, NewType: newType}
 	_ = db.Create(&entry).Error
 }
 
 func logFieldRemove(db *gorm.DB, version, table, column, oldType string) {
-	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, OldType: oldType}
+	entry := FieldHistory{Version: version, Table: table, ColumnName: column, OldType: oldType}
 	_ = db.Create(&entry).Error
 }
 
 func logFieldAlter(db *gorm.DB, version, table, column, fromType, toType string) {
-	entry := FieldHistory{Version: version, TableName: table, ColumnName: column, OldType: fromType, NewType: toType}
+	entry := FieldHistory{Version: version, Table: table, ColumnName: column, OldType: fromType, NewType: toType}
 	_ = db.Create(&entry).Error
 }


### PR DESCRIPTION
## Summary
- rename `FieldHistory` struct's `TableName` field to `Table` to avoid clashing with `TableName()` method

## Testing
- `go vet ./...` *(fails: Forbidden - can't download modules)*
- `go test ./...` *(fails: Forbidden - can't download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68605c5885208330bb0e5d6774e53dc2