### PR TITLE
Improve gorm tag parsing

### DIFF
--- a/gettagvalue_test.go
+++ b/gettagvalue_test.go
@@ -1,0 +1,13 @@
+package driftflow
+
+import "testing"
+
+func TestGetTagValueTrimSpaces(t *testing.T) {
+	tag := "column: display_name ;type: varchar(45)"
+	if got := getTagValue(tag, "column"); got != "display_name" {
+		t.Fatalf("column: got %q", got)
+	}
+	if got := getTagValue(tag, "type"); got != "varchar(45)" {
+		t.Fatalf("type: got %q", got)
+	}
+}

--- a/migrations.go
+++ b/migrations.go
@@ -83,8 +83,9 @@ func getTagValue(tag, key string) string {
 	parts := strings.Split(tag, ";")
 	prefix := key + ":"
 	for _, p := range parts {
-		if strings.HasPrefix(p, prefix) {
-			return strings.TrimPrefix(p, prefix)
+		t := strings.TrimSpace(p)
+		if strings.HasPrefix(t, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(t, prefix))
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary
- trim whitespace when extracting values from gorm struct tags
- add unit test for getTagValue to ensure whitespace is ignored

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68609da8f66c8330ace76ef31b0f00a5