### PR TITLE
Implement seed generation and seeding

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -155,8 +155,11 @@ func newSeedCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var seeders []driftflow.Seeder
-			return driftflow.Seed(db, seedDir, seeders)
+			models, err := helpers.LoadModels()
+			if err != nil {
+				return err
+			}
+			return driftflow.SeedFromJSON(db, seedDir, models)
 		},
 	}
 }
@@ -166,7 +169,10 @@ func newSeedgenCommand() *cobra.Command {
 		Use:   "seedgen",
 		Short: "Generate JSON seed templates from models",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var models []interface{}
+			models, err := helpers.LoadModels()
+			if err != nil {
+				return err
+			}
 			return driftflow.GenerateSeedTemplates(models, seedDir)
 		},
 	}

--- a/helpers/model_loader.go
+++ b/helpers/model_loader.go
@@ -1,15 +1,75 @@
 package helpers
 
 import (
-	"github.com/misaelcrespo30/DriftFlow/internal/models"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
+	"path/filepath"
+
+	"github.com/misaelcrespo30/DriftFlow/internal/models"
 )
 
+// LoadModels validates the directory defined by the MODELS_PATH environment
+// variable and returns the compiled model instances. It ensures at least one
+// exported struct exists in that directory.
 func LoadModels() ([]interface{}, error) {
 	modelPath := os.Getenv("MODELS_PATH")
-	if modelPath != "" && modelPath != "internal/models" {
+	if modelPath == "" {
+		modelPath = "internal/models"
+	}
+
+	info, err := os.Stat(modelPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
 		return nil, os.ErrNotExist
 	}
 
+	files, err := filepath.Glob(filepath.Join(modelPath, "*.go"))
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, os.ErrNotExist
+	}
+
+	hasStruct := false
+	fset := token.NewFileSet()
+	for _, f := range files {
+		astFile, err := parser.ParseFile(fset, f, nil, parser.SkipObjectResolution)
+		if err != nil {
+			continue
+		}
+		for _, decl := range astFile.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
+					continue
+				}
+				if _, ok := ts.Type.(*ast.StructType); ok {
+					hasStruct = true
+					break
+				}
+			}
+			if hasStruct {
+				break
+			}
+		}
+		if hasStruct {
+			break
+		}
+	}
+	if !hasStruct {
+		return nil, os.ErrNotExist
+	}
+
+	// Return the compiled models slice. At the moment models are defined in
+	// the internal/models package.
 	return models.Models(), nil
 }

--- a/seedgen_test.go
+++ b/seedgen_test.go
@@ -21,30 +21,29 @@ func TestGenerateSeedTemplates(t *testing.T) {
 		t.Fatalf("generate: %v", err)
 	}
 
-	// Leer el archivo generado
-	data, err := os.ReadFile(filepath.Join(dir, "tmplmodel.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "tmplmodel.seed.json"))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
 
-	// Deserializar para comparar por estructura
 	var got []tmplModel
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal got: %v", err)
 	}
 
-	// Esperado
-	expected := []tmplModel{{Name: "", Age: 0}}
-
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("unexpected content:\n got: %#v\nwant: %#v", got, expected)
+	if len(got) != 10 {
+		t.Fatalf("expected 10 items, got %d", len(got))
+	}
+	for i, item := range got {
+		if item.Age != i+1 {
+			t.Fatalf("unexpected age at %d: %d", i, item.Age)
+		}
 	}
 }
 
 func TestGenerateSeedTemplatesWithData(t *testing.T) {
 	dir := t.TempDir()
 
-	// Generadores de datos personalizados
 	gens := map[string]func() interface{}{
 		"name": func() interface{} { return "alice" },
 		"age":  func() interface{} { return 30 },
@@ -55,21 +54,20 @@ func TestGenerateSeedTemplatesWithData(t *testing.T) {
 		t.Fatalf("generate: %v", err)
 	}
 
-	// Leer el archivo generado
-	data, err := os.ReadFile(filepath.Join(dir, "tmplmodel.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "tmplmodel.seed.json"))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
 
-	// Deserializar
 	var got []tmplModel
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal got: %v", err)
 	}
 
-	expected := []tmplModel{{Name: "alice", Age: 30}}
-
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("unexpected content:\n got: %#v\nwant: %#v", got, expected)
+	if len(got) != 10 {
+		t.Fatalf("expected 10 items, got %d", len(got))
+	}
+	if got[0].Name != "alice" || got[0].Age != 30 {
+		t.Fatalf("unexpected first item: %#v", got[0])
 	}
 }


### PR DESCRIPTION
## Summary
- validate MODELS_PATH and load compiled models
- generate JSON seed files with dummy data
- add SeedFromJSON to insert seed data
- wire up `driftflow seedgen` and `driftflow seed` commands
- update tests for new generation behaviour

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_6860a371643c83308b95d7fd1ed5af83