### PR TITLE
Avoid rewriting existing seed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ driftflow undo [n]   # rollback the last n migrations (default 1)
 driftflow rollback [n] # alias of undo
 driftflow seed       # execute JSON seed files
 driftflow seedgen    # generate JSON seed templates
+                     # existing seed files are skipped
 driftflow validate   # validate migration directory
 ```
 

--- a/seedgen.go
+++ b/seedgen.go
@@ -58,6 +58,13 @@ func GenerateSeedTemplatesWithData(models []interface{}, dir string, gens map[st
 		file := strings.ToLower(t.Name()) + ".seed.json"
 		path := filepath.Join(dir, file)
 
+		// Skip generation when the seed file already exists
+		if _, err := os.Stat(path); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+
 		objs := make([]*orderedMap, 10)
 		for i := 0; i < 10; i++ {
 			obj := newOrderedMap()

--- a/seedgen_test.go
+++ b/seedgen_test.go
@@ -71,3 +71,24 @@ func TestGenerateSeedTemplatesWithData(t *testing.T) {
 		t.Fatalf("unexpected first item: %#v", got[0])
 	}
 }
+
+func TestGenerateSeedTemplatesSkipExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tmplmodel.seed.json")
+
+	if err := os.WriteFile(path, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("prewrite: %v", err)
+	}
+
+	if err := GenerateSeedTemplates([]interface{}{tmplModel{}}, dir); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("file was overwritten: %s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
- skip generating seed templates if a seed file already exists
- document the new skip behavior in CLI usage
- test that seedgen respects existing files

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686175a28d4c8330b15785ac00295daa