### PR TITLE
seedgen: add default JSON payload generator for unknown JSON fields and test

### DIFF
--- a/seedgen.go
+++ b/seedgen.go
@@ -284,6 +284,7 @@ func ruleValueForField(name string, t reflect.Type, idx int) (interface{}, bool)
 		if strings.Contains(normalized, "domain") {
 			return jsonValue(allowedRootDomains()), true
 		}
+		return defaultJSONValueForField(name, idx), true
 	}
 
 	if strings.Contains(normalized, "domain") && t.Kind() == reflect.String {
@@ -295,6 +296,32 @@ func ruleValueForField(name string, t reflect.Type, idx int) (interface{}, bool)
 	}
 
 	return nil, false
+}
+
+func defaultJSONValueForField(name string, idx int) json.RawMessage {
+	key := strings.TrimSuffix(strings.ToLower(name), "_json")
+	if key == "" {
+		key = "payload"
+	}
+	payload := map[string]interface{}{
+		"type":  key,
+		"index": idx + 1,
+		"status": map[string]interface{}{
+			"code":    "ok",
+			"message": fmt.Sprintf("%s generated", key),
+		},
+		"payload": map[string]interface{}{
+			"id":    fmt.Sprintf("%s_%d", key, idx+1),
+			"source": "seedgen",
+			"active": idx%2 == 0,
+			"tags":   []string{key, "seed", "sample"},
+			"items": []map[string]interface{}{
+				{"name": "item_1", "value": idx + 1},
+				{"name": "item_2", "value": idx + 2},
+			},
+		},
+	}
+	return jsonValue(payload)
 }
 
 func normalizedFieldName(name string) string {

--- a/seedgen_test.go
+++ b/seedgen_test.go
@@ -146,6 +146,49 @@ func TestRuleAllowedRedirectURIsJSON(t *testing.T) {
 	}
 }
 
+func TestRuleGenericJSONFieldGetsObjectPayload(t *testing.T) {
+	value := dummyValueForField("response_json", reflect.TypeOf(JSON{}), 2, time.Now())
+	raw, ok := value.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage, got %T", value)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if payload["type"] != "response" {
+		t.Fatalf("expected type response, got %#v", payload["type"])
+	}
+	if payload["index"] != float64(3) {
+		t.Fatalf("expected index 3, got %#v", payload["index"])
+	}
+
+	status, ok := payload["status"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected status object, got %#v", payload["status"])
+	}
+	if status["code"] != "ok" {
+		t.Fatalf("expected status code ok, got %#v", status["code"])
+	}
+
+	inner, ok := payload["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected payload object, got %#v", payload["payload"])
+	}
+	if inner["id"] != "response_3" {
+		t.Fatalf("expected payload id response_3, got %#v", inner["id"])
+	}
+	if inner["source"] != "seedgen" {
+		t.Fatalf("expected payload source seedgen, got %#v", inner["source"])
+	}
+	tags, ok := inner["tags"].([]interface{})
+	if !ok || len(tags) != 3 {
+		t.Fatalf("expected 3 tags, got %#v", inner["tags"])
+	}
+}
+
 func TestDedupeSeedObjectsByNaturalKey(t *testing.T) {
 	obj1 := newOrderedMap()
 	obj1.set("service_key", "branding")


### PR DESCRIPTION
### Motivation

- Provide a sensible default for fields typed as JSON that are not explicitly handled so seed data is consistent and useful.
- Improve test coverage to assert the structure of generated JSON payloads for generic JSON fields.

### Description

- Call `defaultJSONValueForField` from `ruleValueForField` for JSON-typed fields that don't match specific cases. 
- Add `defaultJSONValueForField` which builds a structured `json.RawMessage` containing `type`, `index`, `status`, and nested `payload` metadata.
- Add unit test `TestRuleGenericJSONFieldGetsObjectPayload` to validate the shape and contents of the generated JSON object.

### Testing

- Ran `go test` for the package; unit tests including `TestRuleGenericJSONFieldGetsObjectPayload` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a216bf68dc83279636622eda4d19b0)